### PR TITLE
Fix error while getting current window in hyper 3

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,13 @@ exports.decorateConfig = config => {
 }
 
 function setTitle(title) {
-  const win = require('electron').remote.getCurrentWindow();
+  let win = null
+  if (require('electron').remote) {
+    win = require('electron').remote.getCurrentWindow();
+  } else {
+    win = require('@electron/remote').getCurrentWindow();
+  }
+  
   win.setTitle(title || DEFAULT_TITLE);
 }
 


### PR DESCRIPTION
When this plugin is installed in Hyper 3 we get the following error
![Screenshot from 2022-10-26 17-02-41](https://user-images.githubusercontent.com/15703806/198073258-9aa52246-29f7-481d-910e-53db52c75d3b.png)

I thought I would share the fix for it.